### PR TITLE
Request camera permissions for scan

### DIFF
--- a/pages/ScanBill.tsx
+++ b/pages/ScanBill.tsx
@@ -43,6 +43,15 @@ export const ScanBill: React.FC = () => {
 
   const captureAndProcessPhoto = async (source: CameraSource) => {
     try {
+      const permission = await Camera.requestPermissions({ permissions: ['camera', 'photos'] });
+      if (
+        (source === CameraSource.Camera && permission.camera !== 'granted') ||
+        (source === CameraSource.Photos && permission.photos !== 'granted')
+      ) {
+        setError('Permisos de cámara o galería denegados.');
+        return;
+      }
+
       const image = await Camera.getPhoto({
         quality: 90,
         allowEditing: false,


### PR DESCRIPTION
## Summary
- request camera and photo permissions before capturing bill
- handle denied permissions with an error message

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6878640364e8832493437478c64fc286